### PR TITLE
feat: add EAS Build configuration for Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.tsbuildinfo
 .env
 .env.local
+google-service-account.json

--- a/apps/formula-sheets/eas.json
+++ b/apps/formula-sheets/eas.json
@@ -1,0 +1,32 @@
+{
+  "cli": {
+    "version": ">= 18.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "android": {
+        "buildType": "app-bundle"
+      },
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {
+      "android": {
+        "serviceAccountKeyPath": "./google-service-account.json",
+        "track": "production"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- EAS Build config with development, preview (APK), and production (AAB) profiles
- Auto-increment version on production builds
- Submit config for Play Store (requires Google service account key)
- google-service-account.json added to .gitignore

Closes #10

## Test plan
- [ ] `eas build --profile preview --platform android` produces APK
- [ ] `eas build --profile production --platform android` produces AAB
- [ ] App installs and runs on Android device